### PR TITLE
adds initial dat reading code based off of paradox's js datreader

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -27,6 +27,14 @@ export default defineNuxtConfig({
   colorMode: {
     preference: "light",
   },
+  runtimeConfig: {
+    // expects there to be subfolders of different dat sets, so a structure might look like:
+    // datDirectory/eor/client_portal.dat
+    // datDirectory/megadat/client_portal.dat
+    // override with NUXT_DAT_DIRECTORY env variable
+    datDirectory: './../dats/',
+    public: {}
+  },
   vite: {
     build: {
       minify: "terser",

--- a/pages/database/skills.vue
+++ b/pages/database/skills.vue
@@ -1,12 +1,45 @@
 <template>
-  <div>Skills</div>
+  <Page>
+    <div v-if="!!error">
+      Error Loading skills
+    </div>
+    <div v-else>
+      <UTable
+        :columns
+        :rows="skills"
+      >
+        <template #name-data="{ row }">
+          <p class="font-bold">
+            {{ row.name }}
+          </p>
+        </template>
+      </UTable>
+    </div>
+  </Page>
 </template>
 
 <script setup lang="ts">
-const route = useRoute()
-console.log(route)
+const datStore = useDatStore()
 
 definePageMeta({
   title: "Skills",
 })
+
+const { data: skills, error } = await useFetch(`/api/dats/${datStore.current}/skills`)
+
+const columns = [
+  {
+    key: "id",
+    label: "Id",
+    class: "w-[0.1%] text-center",
+  },
+  {
+    key: "name",
+    label: "Name",
+  },
+  {
+    key: "description",
+    label: "Description",
+  },
+]
 </script>

--- a/pages/database/sounds.vue
+++ b/pages/database/sounds.vue
@@ -1,12 +1,53 @@
 <template>
-  <div>Sounds</div>
+  <Page>
+    <div v-if="!!error">
+      Error loading sounds
+    </div>
+    <div v-else>
+      <UTable
+        :columns
+        :rows="sounds"
+      >
+        <template #id-data="{ row }">
+          <p class="font-bold">
+            0x{{ ("00000000" + row.toString(16)).slice(-8) }}
+          </p>
+        </template>
+        <template #preview-data="{ row }">
+          <audio
+            controls="true"
+            preload="none"
+          >
+            <source
+              :src="(`/api/dats/${datStore.current}/waves/${row}?stream=1`)"
+              type="audio/wav"
+            >
+            Your browser does not support the audio element.
+          </audio>
+        </template>
+      </UTable>
+    </div>
+  </Page>
 </template>
 
 <script setup lang="ts">
-const route = useRoute()
-console.log(route)
+const datStore = useDatStore()
 
 definePageMeta({
   title: "Sounds",
 })
+
+const { data: sounds, error } = await useFetch(`/api/dats/${datStore.current}/waves`)
+
+const columns = [
+  {
+    key: "id",
+    label: "Id",
+    class: "w-[0.1%] text-center",
+  },
+  {
+    key: "preview",
+    label: "Preview",
+  },
+]
 </script>

--- a/plugins/01.injectAvailableDats.ts
+++ b/plugins/01.injectAvailableDats.ts
@@ -1,0 +1,9 @@
+export default defineNuxtPlugin(async () => {
+  const asyncData = await useFetch("/api/dats")
+
+  return {
+    provide: {
+      availableDats: asyncData.data.value,
+    },
+  }
+})

--- a/server/api/dats/[dat]/skills.ts
+++ b/server/api/dats/[dat]/skills.ts
@@ -1,0 +1,35 @@
+import { join } from "path"
+import { getOrCreateDatLoader } from "~/util/dats/DatLoader"
+import SkillTable from "~/util/dats/filetypes/SkillTable"
+
+const storage = useStorage("DATS")
+
+export default defineEventHandler(async (event) => {
+  const datDirectory = useRuntimeConfig(event).datDirectory
+  const datName = String(event.context.params?.dat)
+  const availableDats = (await storage.getItem<string[]>("available")) ?? []
+
+  if (!availableDats.includes(datName)) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Invalid dat file",
+    })
+  }
+
+  const dat = await getOrCreateDatLoader(join(datDirectory, datName))
+  const skillTable = await dat.Portal.getFile(SkillTable.FILE_ID, SkillTable)
+
+  if (skillTable) {
+    return Object.entries(skillTable.skills).map((skill) => {
+      return {
+        id: skill[0],
+        ...skill[1],
+      }
+    })
+  }
+  else {
+    throw createError({
+      statusCode: 500,
+    })
+  }
+})

--- a/server/api/dats/[dat]/version.ts
+++ b/server/api/dats/[dat]/version.ts
@@ -1,0 +1,48 @@
+import { join } from "path"
+import { getOrCreateDatLoader } from "~/util/dats/DatLoader"
+
+const storage = useStorage("DATS")
+
+export default defineEventHandler(async (event) => {
+  const datDirectory = useRuntimeConfig(event).datDirectory
+  const datName = String(event.context.params?.dat)
+  const availableDats = (await storage.getItem<string[]>("available")) ?? []
+
+  if (!availableDats.includes(datName)) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Invalid dat file",
+    })
+  }
+
+  const dat = await getOrCreateDatLoader(join(datDirectory, datName))
+
+  if (dat) {
+    return {
+      name: datName,
+      cell: {
+        versionEngine: dat.Cell.versionEngine,
+        versionGame: dat.Cell.versionGame,
+        versionMinor: dat.Cell.versionMinor,
+        versionMajor: dat.Cell.versionMajor,
+      },
+      portal: {
+        versionEngine: dat.Portal.versionEngine,
+        versionGame: dat.Portal.versionGame,
+        versionMinor: dat.Portal.versionMinor,
+        versionMajor: dat.Portal.versionMajor,
+      },
+      language: {
+        versionEngine: dat.Language.versionEngine,
+        versionGame: dat.Language.versionGame,
+        versionMinor: dat.Language.versionMinor,
+        versionMajor: dat.Language.versionMajor,
+      },
+    }
+  }
+  else {
+    throw createError({
+      statusCode: 500,
+    })
+  }
+})

--- a/server/api/dats/[dat]/waves/[id].ts
+++ b/server/api/dats/[dat]/waves/[id].ts
@@ -1,0 +1,112 @@
+import { join } from "path"
+import { getOrCreateDatLoader } from "~/util/dats/DatLoader"
+import Wave from "~/util/dats/filetypes/Wave"
+
+const storage = useStorage("DATS")
+
+export default defineEventHandler(async (event) => {
+  const datDirectory = useRuntimeConfig(event).datDirectory
+  const datName = String(event.context.params?.dat)
+  const fileId = Number(event.context.params?.id)
+  const respondWithStream = !!getQuery(event)?.stream
+  const availableDats = (await storage.getItem<string[]>("available")) ?? []
+
+  if (!availableDats.includes(datName) || (fileId <= 0x0A000000 || fileId >= 0x0A00FFFF)) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: `Invalid dat file: ${("00000000" + fileId.toString(16)).slice(-8)}`,
+    })
+  }
+
+  const dat = await getOrCreateDatLoader(join(datDirectory, datName))
+  const wave = await dat.Portal.getFile(fileId, Wave)
+
+  if (wave && wave.header && wave.body) {
+    if (respondWithStream) {
+      // data stream logic ripped from ACE
+      const arr = new Uint8Array(wave.body.length + 44)
+      const dv = new DataView(arr.buffer)
+      const txtEncoder = new TextEncoder()
+
+      let offset = 0
+
+      const riffText = txtEncoder.encode("RIFF")
+      for (let i = 0; i < riffText.length; i++) {
+        dv.setUint8(offset++, riffText[i])
+      }
+
+      dv.setUint32(offset, wave.body.length + 36, true)
+      offset += 4
+
+      const wavText = txtEncoder.encode("WAVE")
+      for (let i = 0; i < wavText.length; i++) {
+        dv.setUint8(offset++, wavText[i])
+      }
+
+      const fmtText = txtEncoder.encode("fmt")
+      for (let i = 0; i < fmtText.length; i++) {
+        dv.setUint8(offset++, fmtText[i])
+      }
+      dv.setUint8(offset++, 0x20) // null ending to fmt
+
+      dv.setInt32(offset, 0x10, true)
+      offset += 4
+
+      // AC audio headers start at Format Type,
+      // and are usually 18 bytes, with some exceptions
+      // notably objectID A000393 which is 30 bytes
+
+      // WAV headers are always 16 bytes from Format Type to end of header,
+      // so this extra data is truncated here.
+      for (let i = 0; i < 16; i++) {
+        dv.setInt8(offset++, wave.header[i])
+      }
+
+      const dataText = txtEncoder.encode("data")
+      for (let i = 0; i < dataText.length; i++) {
+        dv.setUint8(offset++, dataText[i])
+      }
+
+      dv.setUint32(offset, wave.body.length, true)
+      offset += 4
+
+      for (let i = 0; i < wave.body.length; i++) {
+        dv.setUint8(offset++, wave.body[i])
+      }
+
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(arr)
+          controller.close()
+        },
+      })
+
+      if (wave.header[0] == 0x55) {
+        setResponseHeaders(event, {
+          "Content-Disposition": `attachment; filename=${("00000000" + fileId.toString(16)).slice(-8)}.mp3`,
+          "Content-Type": "audio/mp3",
+        })
+      }
+      else {
+        setResponseHeaders(event, {
+          "Content-Disposition": `attachment; filename=${("00000000" + fileId.toString(16)).slice(-8)}.wav`,
+          "Content-Type": "audio/wav",
+        })
+      }
+
+      sendStream(event, stream)
+    }
+    else {
+      return {
+        id: wave.fileId,
+        header: wave.header,
+        body: wave.body,
+      }
+    }
+  }
+  else {
+    throw createError({
+      statusCode: 404,
+    })
+  }
+})

--- a/server/api/dats/[dat]/waves/index.ts
+++ b/server/api/dats/[dat]/waves/index.ts
@@ -1,0 +1,22 @@
+import { join } from "path"
+import { getOrCreateDatLoader } from "~/util/dats/DatLoader"
+
+const storage = useStorage("DATS")
+
+export default defineEventHandler(async (event) => {
+  const datDirectory = useRuntimeConfig(event).datDirectory
+  const datName = String(event.context.params?.dat)
+  const availableDats = (await storage.getItem<string[]>("available")) ?? []
+
+  if (!availableDats.includes(datName)) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Invalid dat file",
+    })
+  }
+
+  const dat = await getOrCreateDatLoader(join(datDirectory, datName))
+  const waves = await dat.Portal.getFileEntries(0x0A000000, 0x0A00FFFF)
+
+  return waves.map(w => w.id)
+})

--- a/server/api/dats/index.ts
+++ b/server/api/dats/index.ts
@@ -1,0 +1,3 @@
+export default cachedEventHandler(async () => {
+  return await useStorage("DATS").getItem<string[]>("available")
+})

--- a/server/plugins/01.datFinder.ts
+++ b/server/plugins/01.datFinder.ts
@@ -1,0 +1,16 @@
+import { readdir } from "node:fs/promises"
+
+export default defineNitroPlugin(async () => {
+  const storage = useStorage("DATS")
+  const datDirectory = useRuntimeConfig().datDirectory
+
+  try {
+    const files = await readdir(datDirectory)
+    await storage.setItem<string[]>("available", files)
+
+    console.log(`Dats fetched succesfully! (${files.join(", ")})`)
+  }
+  catch (err) {
+    console.error(`Error reading datDirectory (${datDirectory}): ${err}`)
+  }
+})

--- a/stores/dat.ts
+++ b/stores/dat.ts
@@ -1,0 +1,15 @@
+import { defineStore } from "pinia"
+
+export const useDatStore = defineStore("dat", {
+  state: () => ({
+    _current: null,
+  }),
+  getters: {
+    available() {
+      return useNuxtApp().$availableDats ?? []
+    },
+    current(state): string | null {
+      return (state._current ?? (this.available.length > 0 ? this.available[0] : null))
+    },
+  },
+})

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -1,10 +1,10 @@
 // store/filters.js
-import { defineStore } from "pinia";
+import { defineStore } from "pinia"
 
 export const useStore = defineStore("store", () => {
-  const now = ref(Date.now());
-  const titlePhrase = ref(null);
-  const siteSearchFilter = ref("");
+  const now = ref(Date.now())
+  const titlePhrase = ref(null)
+  const siteSearchFilter = ref("")
 
   const primaryNav = ref([
     {
@@ -230,12 +230,12 @@ export const useStore = defineStore("store", () => {
         ],
       ],
     },
-  ]);
+  ])
 
   return {
     primaryNav,
     titlePhrase,
     siteSearchFilter,
     now,
-  };
-});
+  }
+})

--- a/util/dats/DatDatabase.ts
+++ b/util/dats/DatDatabase.ts
@@ -1,0 +1,193 @@
+import type { FileHandle } from "node:fs/promises"
+import { open } from "node:fs/promises"
+import type { DatDatabaseType } from "./DatDatabaseType"
+import DatReader from "./DatReader"
+import { DatDirectory } from "./DatDirectory"
+import type { DatFileEntry } from "./DatDirectory"
+import type DatFile from "./DatFile"
+
+export class DatDatabase {
+  filepath: string
+  type: DatDatabaseType
+
+  fileHandle: FileHandle | undefined
+  reader: DatReader | undefined
+
+  fileCache: Record<number, DatFileEntry> = {}
+
+  magic: number = 0
+  blockSize: number = 0
+  fileSize: number = 0
+  dbType: number = 0
+  subType: number = 0
+  freeStart: number = 0
+  freeEnd: number = 0
+  freeCount: number = 0
+  root: number = 0
+
+  newLRU: number = 0
+  oldLRU: number = 0
+  useLRU: number = 0
+
+  masterMap: number = 0
+
+  versionEngine: number = 0
+  versionGame: number = 0
+  versionMajor: Uint8Array | undefined
+  versionMinor: number = 0
+
+  constructor(filepath: string, type: DatDatabaseType) {
+    this.filepath = filepath
+    this.type = type
+  }
+
+  async init() {
+    try {
+      this.fileHandle = await open(this.filepath, "r")
+
+      if (this.fileHandle) {
+        await this.#readHeader()
+      }
+
+      return true
+    }
+    catch (e) {
+      console.error(`Error opening ${this.type} dat file: ${this.filepath}`)
+    }
+
+    return false
+  }
+
+  async #readHeader() {
+    const dv = new DataView(new ArrayBuffer(64 + 16 + 4))
+    await this.fileHandle?.read(dv, 0, 64 + 16 + 4, 256 + 64)
+
+    const reader = new DatReader(dv)
+    this.reader = reader
+
+    this.magic = reader.getUint32()
+    this.blockSize = reader.getUint32()
+    this.fileSize = reader.getUint32()
+    this.dbType = reader.getUint32()
+    this.subType = reader.getUint32()
+    this.freeStart = reader.getUint32()
+    this.freeEnd = reader.getUint32()
+    this.freeCount = reader.getUint32()
+    this.root = reader.getUint32()
+
+    this.newLRU = reader.getUint32()
+    this.oldLRU = reader.getUint32()
+    this.useLRU = reader.getUint32()
+
+    this.masterMap = reader.getUint32()
+
+    this.versionEngine = reader.getUint32()
+    this.versionGame = reader.getUint32()
+    this.versionMajor = reader.getUint8Array(16)
+    this.versionMinor = reader.getUint32()
+  }
+
+  async getFile<T extends DatFile>(id: number, fileCtor: new () => T): Promise<T | null> {
+    try {
+      let fe: DatFileEntry | null = this.fileCache[id]
+      if (!fe) {
+        fe = await this.#findFile(id)
+      }
+      if (fe) {
+        const file = new fileCtor()
+        await file.unpack(this, fe.offset, fe.size)
+        return file
+      }
+    }
+    catch (e) { console.error(e) }
+    return null
+  }
+
+  async #findFile(id: number) {
+    let current = this.root
+    // console.log("find file", id.toHexStr(), current.toHexStr());
+    let lastCurrent = 0
+    while (current !== 0 && current !== 0xcdcdcdcd) {
+      const entry = new DatDirectory(this, current)
+      await entry.load()
+
+      this.#cacheFiles(entry)
+
+      let l = 0
+      let r = entry.fileCount - 1
+      let i = 0
+
+      while (l <= r) {
+        i = ((l + r) / 2) | 0
+        let fe = null
+        try {
+          fe = entry.files[i]
+        }
+        catch (error) {
+          console.error("failed to get fileEntry", current, i, entry.fileCount)
+        }
+        if (!fe) {
+          console.error("failed to get fileEntry", current, i, entry.fileCount)
+        }
+
+        if (id === fe?.id) {
+          return fe
+        }
+        else if (fe && id < fe.id) {
+          r = i - 1
+        }
+        else {
+          l = i + 1
+        }
+      }
+
+      if (entry.isLeaf)
+        break
+
+      if (id > entry.files[i].id)
+        i++
+
+      current = entry.folders![i]
+      if (lastCurrent == current) {
+        console.error(`dat directory looping... ${current}: ${(entry.folders || []).join(",")}`)
+        break
+      }
+      lastCurrent = current
+    }
+    return null
+  }
+
+  #cacheFiles(node: DatDirectory) {
+    for (let i = 0; i < node.fileCount; i++) {
+      const f = node.files[i]
+      if (!f) {
+        // console.log('bad file', node.offset.toHexStr(), i);
+        continue
+      }
+      this.fileCache[f.id] = f
+    }
+  }
+
+  async loadFileCache() {
+    await this.#loadDirectoryFiles(new DatDirectory(this, this.root))
+  }
+
+  async #loadDirectoryFiles(node: DatDirectory) {
+    this.#cacheFiles(node)
+    if (!node.isLeaf) {
+      for (let i = 0; i < 62; i++) {
+        const offset = node.folders![i]
+        // if (offset > this.fileSize) console.log('node offset', offset.toHexStr());
+        if (offset != 0 && offset != 0xcdcdcd && offset < this.fileSize) {
+          const dir = new DatDirectory(this, offset)
+          await dir.load()
+          this.#loadDirectoryFiles(dir)
+        }
+      }
+    }
+  }
+
+  close() {
+    this.fileHandle?.close()
+  }
+}

--- a/util/dats/DatDatabaseType.ts
+++ b/util/dats/DatDatabaseType.ts
@@ -1,0 +1,6 @@
+export enum DatDatabaseType {
+  Cell = "Cell",
+  Portal = "Portal",
+  Language = "Language",
+  HighRes = "HighRes",
+}

--- a/util/dats/DatDirectory.ts
+++ b/util/dats/DatDirectory.ts
@@ -1,0 +1,92 @@
+import type { DatDatabase } from "./DatDatabase"
+
+export interface DatFileEntry {
+  flag: number
+  id: number
+  offset: number
+  size: number
+  time: number
+  version: number
+}
+
+export class DatDirectory {
+  dat: DatDatabase
+  offset: number
+  folders: Uint32Array | null = null
+  files: DatFileEntry[] = []
+  fileCount = -1
+  isLeaf = true
+
+  constructor(dat: DatDatabase, offset: number) {
+    this.dat = dat
+    this.offset = offset
+  }
+
+  async load() {
+    let blk_offset = this.offset
+    let data_offset = 4
+
+    const dat = this.dat
+
+    const block = new DataView(new ArrayBuffer(this.dat.blockSize))
+    await dat.fileHandle?.read(block, 0, this.dat.blockSize, blk_offset)
+
+    const folderData = new DataView(new ArrayBuffer(62 * 4))
+    await dat.fileHandle?.read(folderData, 0, 62 * 4, blk_offset + data_offset)
+
+    this.folders = new Uint32Array(folderData.buffer, 0, 62)
+    data_offset += 248 // 62 * 4;
+
+    this.isLeaf = !this.folders[0]
+    this.fileCount = block.getInt32(data_offset, true)
+    if (this.fileCount > 61)
+      console.log("node entry count", this.offset, data_offset, this.fileCount)
+    data_offset += 4
+
+    const getEntryChunk = async function () {
+      let need = 6
+      const chunk = new Uint32Array(need)
+      let left = Math.min(dat.blockSize - data_offset, need * 4)
+      let idx = 0
+
+      while (need > 0) {
+        const cnt = (left / 4) | 0
+        if (cnt > 0) {
+          const tmpView = new DataView(new ArrayBuffer(cnt * 4))
+          await dat.fileHandle?.read(tmpView, 0, cnt * 4, blk_offset + data_offset)
+          const tmp = new Uint32Array(tmpView.buffer, 0, cnt)
+          chunk.set(tmp, idx)
+          need -= cnt
+          idx += cnt
+
+          if (need === 0) {
+            data_offset += cnt * 4
+            break
+          }
+        }
+
+        blk_offset = block.getInt32(0, true)
+        data_offset = 4
+
+        await dat.fileHandle?.read(block, 0, dat.blockSize, blk_offset)
+
+        left = Math.min(dat.blockSize - data_offset, need * 4)
+      }
+
+      return chunk
+    }
+
+    for (let i = 0; i < 61; i++) {
+      const chunk = await getEntryChunk()
+      const fe = {
+        flag: chunk[0],
+        id: chunk[1],
+        offset: chunk[2],
+        size: chunk[3],
+        time: chunk[4],
+        version: chunk[5],
+      }
+      this.files.push(fe)
+    }
+  }
+}

--- a/util/dats/DatFile.ts
+++ b/util/dats/DatFile.ts
@@ -1,0 +1,36 @@
+import type { DatDatabase } from "./DatDatabase"
+import DatReader from "./DatReader"
+
+export default class DatFile {
+  data: Uint8Array | undefined
+  fileId: number = 0
+  reader?: DatReader
+
+  async unpack(db: DatDatabase, offset: number, size: number) {
+    let read = size
+    let blk_offset = offset
+    let data_offset = 0
+
+    this.data = new Uint8Array(size)
+
+    while (read > 0) {
+      const cnt = Math.min(db.blockSize - 4, read)
+      const block = new DataView(new ArrayBuffer(db.blockSize))
+      await db.fileHandle?.read(block, 0, cnt, blk_offset)
+      this.data.set(new Uint8Array(block.buffer, 4, cnt), data_offset)
+
+      data_offset += cnt
+      read -= cnt
+      blk_offset = block.getInt32(0, true)
+    }
+
+    this.reader = new DatReader(new DataView(this.data.buffer))
+    this.fileId = this.reader.getUint32()
+
+    return true
+  }
+
+  pack(db: DatDatabase) {
+    return Promise.reject(`Not implemented... ${db}`)
+  }
+}

--- a/util/dats/DatLoader.ts
+++ b/util/dats/DatLoader.ts
@@ -1,0 +1,46 @@
+import { join } from "path"
+import { DatDatabaseType } from "./DatDatabaseType"
+import { DatDatabase } from "./DatDatabase"
+import type DatFile from "./DatFile"
+
+const loaders: Record<string, DatLoader> = {}
+
+export async function getOrCreateDatLoader(datDirectory: string) {
+  if (loaders[datDirectory]) {
+    return loaders[datDirectory]
+  }
+
+  loaders[datDirectory] = new DatLoader(datDirectory)
+  await loaders[datDirectory].init()
+  return loaders[datDirectory]
+}
+
+export class DatLoader {
+  datDirectory: string
+
+  Cell: DatDatabase
+  Portal: DatDatabase
+  Language: DatDatabase
+
+  constructor(datDirectory: string) {
+    this.datDirectory = datDirectory
+
+    this.Cell = new DatDatabase(join(datDirectory, "client_cell_1.dat"), DatDatabaseType.Cell)
+    this.Portal = new DatDatabase(join(datDirectory, "client_portal.dat"), DatDatabaseType.Portal)
+    this.Language = new DatDatabase(join(datDirectory, "client_local_English.dat"), DatDatabaseType.Language)
+  }
+
+  async init() {
+    return await this.Cell.init() && await this.Portal.init() && await this.Language.init()
+  }
+
+  async getPortalFile<T extends DatFile>(id: number, fileCtor: new () => T): Promise<T | null> {
+    return await this.Portal.getFile<T>(id, fileCtor)
+  }
+
+  close() {
+    this.Cell.close()
+    this.Portal.close()
+    this.Language.close()
+  }
+}

--- a/util/dats/DatLoader.ts
+++ b/util/dats/DatLoader.ts
@@ -11,7 +11,11 @@ export async function getOrCreateDatLoader(datDirectory: string) {
   }
 
   loaders[datDirectory] = new DatLoader(datDirectory)
+  const t0 = performance.now()
   await loaders[datDirectory].init()
+  const t1 = performance.now()
+  console.log(`Took ${((t1 - t0) / 1000).toFixed(3)}s to load dats from ${datDirectory}`)
+
   return loaders[datDirectory]
 }
 
@@ -31,7 +35,11 @@ export class DatLoader {
   }
 
   async init() {
-    return await this.Cell.init() && await this.Portal.init() && await this.Language.init()
+    const didCellInit = await this.Cell.init()
+    const didPortalInit = await this.Portal.init()
+    const didLanguageInit = await this.Language.init()
+
+    return didCellInit && didPortalInit && didLanguageInit
   }
 
   async getPortalFile<T extends DatFile>(id: number, fileCtor: new () => T): Promise<T | null> {

--- a/util/dats/DatReader.ts
+++ b/util/dats/DatReader.ts
@@ -1,0 +1,165 @@
+export default class DatReader {
+  view: DataView
+  buffer: ArrayBuffer
+  position: number
+  encoder: TextDecoder
+
+  constructor(view: DataView) {
+    this.buffer = view.buffer
+    this.view = view
+    this.position = 0
+    this.encoder = new TextDecoder()
+  }
+
+  _incRead(fn: (byteOffset: number, someBool: boolean) => number, cnt: number) {
+    try {
+      const res = fn.apply(this.view, [this.position, cnt > 1])
+      this.position += cnt
+      return res
+    }
+    catch (error) {
+      console.error("dat read fail", this, error)
+      throw error
+    }
+  }
+
+  align() {
+    const offset = this.position % 4
+    if (offset !== 0)
+      this.position += 4 - offset
+  }
+
+  getString() {
+    const len = this.getInt16()
+    const res = this.encoder.decode(new Uint8Array(this.buffer, this.position, len))
+    this.position += len
+    return res
+  }
+
+  getInt8() { return this._incRead(DataView.prototype.getInt8, 1) }
+  getUint8() { return this._incRead(DataView.prototype.getUint8, 1) }
+  getInt16() { return this._incRead(DataView.prototype.getInt16, 2) }
+  getUint16() { return this._incRead(DataView.prototype.getUint16, 2) }
+  getInt32() { return this._incRead(DataView.prototype.getInt32, 4) }
+  getUint32() { return this._incRead(DataView.prototype.getUint32, 4) }
+  getFloat() { return this._incRead(DataView.prototype.getFloat32, 4) }
+  getDouble() { return this._incRead(DataView.prototype.getFloat64, 8) }
+
+  getSingle() { return this.getFloat() }
+
+  getPackedInt16() {
+    let tmp = this.getUint8()
+    if ((tmp & 0x80) !== 0) {
+      tmp = (tmp & 0x7f) << 8
+      tmp |= this.getUint8()
+    }
+    return tmp
+  }
+
+  getPackedInt32() {
+    const b0 = this.getUint8()
+    let result = b0
+    if ((b0 & 0x80) !== 0) {
+      const b1 = this.getUint8()
+      result = ((b0 & 0x7f) << 8) | b1
+
+      if ((b0 & 0x40) !== 0) {
+        const s1 = this.getUint16()
+        result = ((b0 & 0x3f) << 24) | (b1 << 16) | s1
+      }
+    }
+
+    return result
+  }
+
+  getVector2() {
+    return {
+      x: this.getFloat(),
+      y: this.getFloat(),
+    }
+  }
+
+  getVector3() {
+    return {
+      x: this.getFloat(),
+      y: this.getFloat(),
+      z: this.getFloat(),
+    }
+  }
+
+  getQuaternion() {
+    return {
+      w: this.getFloat(),
+      x: this.getFloat(),
+      y: this.getFloat(),
+      z: this.getFloat(),
+    }
+  }
+
+  /*
+  getMany(ctor, cnt) {
+    let res = null
+    try {
+      cnt = cnt !== undefined ? cnt : this.getInt32()
+      res = new Array(cnt)
+      for (let i = 0; i < cnt; i++)
+        res[i] = ctor(this)
+
+      return res
+    }
+    catch (error) {
+      // console.log(res);
+      throw error
+    }
+  }
+  */
+
+  getInt8Array(cnt: number) {
+    cnt = cnt !== undefined ? cnt : this.getInt32()
+    const res = new Int8Array(this.buffer, this.position, cnt)
+    this.position += res.byteLength
+    return res
+  }
+
+  getUint8Array(cnt: number) {
+    cnt = cnt !== undefined ? cnt : this.getInt32()
+    const res = new Uint8Array(this.buffer, this.position, cnt)
+    this.position += res.byteLength
+    return res
+  }
+
+  getInt16Array(cnt: number) {
+    const cntp = cnt
+    cnt = cnt !== undefined ? cnt : this.getInt32()
+    try {
+      const tmp = new Uint8Array(this.buffer, this.position, cnt * 2)
+      const res = new Int16Array(tmp.buffer, 0, cnt)
+      this.position += tmp.byteLength
+      return res
+    }
+    catch (error) {
+      console.log("getInt16Array", cntp, cnt, error, this)
+    }
+  }
+
+  getUint16Array(cnt: number) {
+    cnt = cnt !== undefined ? cnt : this.getInt32()
+    const res = new Uint16Array(this.buffer, this.position, cnt)
+    this.position += res.byteLength
+    return res
+  }
+
+  getInt32Array(cnt: number) {
+    cnt = cnt !== undefined ? cnt : this.getInt32()
+    const res = new Int32Array(this.buffer, this.position, cnt)
+    this.position += res.byteLength
+    return res
+  }
+
+  getUint32Array(cnt: number) {
+    cnt = cnt !== undefined ? cnt : this.getInt32()
+    const res = new Uint32Array(this.buffer, this.position, cnt)
+    this.position += res.byteLength
+    return res
+  }
+}

--- a/util/dats/IDatPackable.ts
+++ b/util/dats/IDatPackable.ts
@@ -1,0 +1,9 @@
+import type DatReader from "./DatReader"
+
+export interface Unpack {
+  (reader: DatReader): Promise<boolean>
+}
+
+export interface IDatPackable {
+  unpack: Unpack
+}

--- a/util/dats/entities/SkillBase.ts
+++ b/util/dats/entities/SkillBase.ts
@@ -28,7 +28,7 @@ export class SkillBase implements IDatPackable {
     this.chargenUse = reader.getUint32()
     this.minLevel = reader.getUint32()
     this.formula = new SkillFormula()
-    this.formula.unpack(reader)
+    await this.formula.unpack(reader)
     this.upperBound = reader.getDouble()
     this.lowerBound = reader.getDouble()
     this.learnMod = reader.getDouble()

--- a/util/dats/entities/SkillBase.ts
+++ b/util/dats/entities/SkillBase.ts
@@ -1,0 +1,37 @@
+import type DatReader from "../DatReader"
+import type { IDatPackable } from "../IDatPackable"
+import SkillFormula from "./SkillFormula"
+
+export class SkillBase implements IDatPackable {
+  description?: string
+  name?: string
+  iconId?: number
+  trainedCost?: number
+  specializedCost?: number
+  category?: number
+  chargenUse?: number
+  minLevel?: number
+  formula?: SkillFormula
+  upperBound?: number
+  lowerBound?: number
+  learnMod?: number
+
+  async unpack(reader: DatReader) {
+    this.description = reader.getString()
+    reader.align()
+    this.name = reader.getString()
+    reader.align()
+    this.iconId = reader.getUint32()
+    this.trainedCost = reader.getInt32()
+    this.specializedCost = reader.getInt32()
+    this.category = reader.getUint32()
+    this.chargenUse = reader.getUint32()
+    this.minLevel = reader.getUint32()
+    this.formula = new SkillFormula()
+    this.formula.unpack(reader)
+    this.upperBound = reader.getDouble()
+    this.lowerBound = reader.getDouble()
+    this.learnMod = reader.getDouble()
+    return true
+  }
+}

--- a/util/dats/entities/SkillFormula.ts
+++ b/util/dats/entities/SkillFormula.ts
@@ -1,0 +1,24 @@
+import type DatReader from "../DatReader"
+import type { IDatPackable } from "../IDatPackable"
+
+export default class SkillFormula implements IDatPackable {
+  W?: number
+  X?: number
+  Y?: number
+  Z?: number
+  Attr1?: number
+  Attr2?: number
+
+  get Divisor() { return this.X }
+  set Divisor(value) { this.X = value }
+
+  async unpack(reader: DatReader) {
+    this.W = reader.getUint32()
+    this.X = reader.getUint32()
+    this.Y = reader.getUint32()
+    this.Z = reader.getUint32()
+    this.Attr1 = reader.getUint32()
+    this.Attr2 = reader.getUint32()
+    return !!reader
+  }
+}

--- a/util/dats/filetypes/SkillTable.ts
+++ b/util/dats/filetypes/SkillTable.ts
@@ -21,6 +21,7 @@ export default class SkillTable extends DatFile {
         this.skills[key] = item
       }
     }
-    return false
+
+    return true
   }
 }

--- a/util/dats/filetypes/SkillTable.ts
+++ b/util/dats/filetypes/SkillTable.ts
@@ -1,0 +1,26 @@
+import type { DatDatabase } from "../DatDatabase"
+import DatFile from "../DatFile"
+import { SkillBase } from "../entities/SkillBase"
+
+export default class SkillTable extends DatFile {
+  static readonly FILE_ID = 0x0E000004
+
+  skills: Record<number, SkillBase> = {}
+
+  async unpack(db: DatDatabase, offset: number, size: number) {
+    if (await super.unpack(db, offset, size) && this.reader) {
+      const totalObjects = this.reader.getUint16()
+      /* const bucketSize = */this.reader.getUint16()
+
+      for (let i = 0; i < totalObjects; i++) {
+        const key = this.reader.getUint32()
+
+        const item = new SkillBase()
+        await item.unpack(this.reader)
+
+        this.skills[key] = item
+      }
+    }
+    return false
+  }
+}

--- a/util/dats/filetypes/Wave.ts
+++ b/util/dats/filetypes/Wave.ts
@@ -1,0 +1,19 @@
+import type { DatDatabase } from "../DatDatabase"
+import DatFile from "../DatFile"
+
+export default class Wave extends DatFile {
+  header?: Uint8Array
+  body?: Uint8Array
+
+  async unpack(db: DatDatabase, offset: number, size: number) {
+    if (await super.unpack(db, offset, size) && this.reader) {
+      const headerSize = this.reader.getInt32()
+      const bodySize = this.reader.getInt32()
+
+      this.header = this.reader.getUint8Array(headerSize)
+      this.body = this.reader.getUint8Array(bodySize)
+    }
+
+    return true
+  }
+}


### PR DESCRIPTION
Also adds minimal skills / sounds pages with info pulled from dats.

Not positive about dumping everything under utils...

The datStore is maybe a little weird... the idea is that you could have a dropdown on the site somewhere to switch between server dats

This does require a new environment variable and access to the dats:

```ts
  runtimeConfig: {
    // expects there to be subfolders of different dat sets, so a structure might look like:
    // datDirectory/eor/client_portal.dat
    // datDirectory/megadat/client_portal.dat
    // override with NUXT_DAT_DIRECTORY env variable
    datDirectory: './../dats/'
  },
```